### PR TITLE
Testing changes

### DIFF
--- a/src/Base/Transformer/TsAssocArrayTransformer.php
+++ b/src/Base/Transformer/TsAssocArrayTransformer.php
@@ -22,9 +22,7 @@ class TsAssocArrayTransformer implements TsTypeTransformerContract
         return false;
       }
 
-      $keyType = $type->getKeyType();
-
-      return ! $keyType instanceof \PHPStan\Type\IntegerType;
+      return $type->getKeyType()->isInteger()->no();
     }
 
     public static function transform(Type $type, Scope $scope, ReflectionProvider $reflectionProvider): TsType {

--- a/src/Base/Transformer/TsSimpleArrayTransformer.php
+++ b/src/Base/Transformer/TsSimpleArrayTransformer.php
@@ -9,6 +9,7 @@ use PHPStan\Type\Type;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\StringType;
 
 /**
  * A simple homogeneous array type. For example: `string[]`, `number[]`, `(string | number)[]`, `never[]`, etc.
@@ -20,9 +21,7 @@ class TsSimpleArrayTransformer implements TsTypeTransformerContract
             return false;
         }
 
-        $keyType = $type->getKeyType();
-
-        return $keyType instanceof \PHPStan\Type\IntegerType;
+        return !$type->getKeyType()->isInteger()->no();
     }
 
     public static function transform(Type $type, Scope $scope, ReflectionProvider $reflectionProvider): TsSimpleArrayType {

--- a/src/Base/Transformer/_ArrayLikeParserHelper.php
+++ b/src/Base/Transformer/_ArrayLikeParserHelper.php
@@ -13,7 +13,7 @@ class _ArrayLikeParserHelper
 {
     public static function transform(Type $keyType, Type $valueType, Scope $scope, ReflectionProvider $reflectionProvider): TsSimpleArrayType|TsRecordType
     {
-        if ($keyType->isInteger()->yes()) {
+        if (!$keyType->isInteger()->no()) {
             return new TsSimpleArrayType(TsTransformer::transform($valueType, $scope, $reflectionProvider));
         }
 

--- a/src/LaravelData/Transformer/LaravelDataPaginatedTransformer.php
+++ b/src/LaravelData/Transformer/LaravelDataPaginatedTransformer.php
@@ -21,12 +21,12 @@ class LaravelDataPaginatedTransformer implements TsTypeTransformerContract
 
       $unionTypes = $type->getTypes();
 
-      if (count($unionTypes) !== 2) {
-        return false;
-      }
+      // if (count($unionTypes) !== 2) {
+      //   return false;
+      // }
 
       foreach ($unionTypes as $unionType) {
-        if (!$unionType instanceof \PHPStan\Type\ObjectType) {
+        if (!$unionType instanceof \PHPStan\Type\ObjectType && !$unionType instanceof \PHPStan\Type\ArrayType) {
           return false;
         }
       }
@@ -40,10 +40,14 @@ class LaravelDataPaginatedTransformer implements TsTypeTransformerContract
     }
 
     /**
-     * @param \PHPStan\Type\ObjectType[] $types
+     * @param (\PHPStan\Type\ObjectType | \PHPStan\Type\ArrayType)[] $types
      */
     protected static function getPaginator(array $types, ReflectionProvider $reflectionProvider): ?Type {
       $paginator = array_filter($types, function ($type) use ($reflectionProvider) {
+        if (!$type instanceof \PHPStan\Type\ObjectType) {
+          return false;
+        }
+
         if ($type->getClassName() === 'Illuminate\Pagination\AbstractPaginator') {
           return true;
         }
@@ -57,11 +61,7 @@ class LaravelDataPaginatedTransformer implements TsTypeTransformerContract
         return $reflection->isSubclassOfClass($reflectionProvider->getClass('Illuminate\Pagination\AbstractPaginator'));
       });
 
-      if (count($paginator) === 1) {
-        return array_pop($paginator);
-      }
-
-      return null;
+      return array_pop($paginator);
     }
 
     /**
@@ -74,11 +74,7 @@ class LaravelDataPaginatedTransformer implements TsTypeTransformerContract
         return $type->isIterable()->yes();
       });
 
-      if (count($types) !== 1) {
-        return null;
-      }
-
-      return array_pop($types)->getIterableValueType();
+      return array_pop($types)?->getIterableValueType();
     }
 
     public static function transform(Type $type, Scope $scope, ReflectionProvider $reflectionProvider): TsType {


### PR DESCRIPTION
Collection of changes i had to implement get this lib to work with a demo project.

1. While a `record` might be the correct type when transforming to ts, in practice, nearly everything was a record then. The current change is super dirty and would be better implemented by a "is list" check. But not sure, if the approach is compatible then with 3rd party libraries like LaravelData (thinking about the return type of `::collect()` here).

2. `::collect()` returned its whole union of return types (e.g. `array|DataCollection|PaginatedDataCollection|CursorPaginatedDataCollection|Enumerable|AbstractPaginator|PaginatorContract|AbstractCursorPaginator|CursorPaginatorContract|LazyCollection|Collection`) necessitating the deletion of the count checks. Not sure how we can improve this.

3. The argument of `LiteralTypescriptType` Attributes has to be evaluated explicitly since its argument is a string and not a type. If evaluating it via `::transform()` the return type would be the type of a constant string with the argument value. But the argument value itself is needed as a type. Therefor we handle it explicitly. PHPstan should be able to analyze it statically most of the time, since the attribute arguments needs to be literal or a constant expression (see https://www.php.net/manual/en/language.attributes.syntax.php).